### PR TITLE
build: remove prefix from angular components and other building block

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -12,7 +12,7 @@
       },
       "root": "",
       "sourceRoot": "src",
-      "prefix": "app",
+      "prefix": "",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:application",


### PR DESCRIPTION
This pull request includes a small change to the `angular.json` file. The change removes the `prefix` property from the configuration.

* [`angular.json`](diffhunk://#diff-2d2675bb4687601a5c7ccf707455132f90f3516a33716185687e5c41df59ac7dL15-R15): Removed the `prefix` property from the configuration.