### PR TITLE
ci: add comment to failed PR checks

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -6,16 +6,40 @@ on:
       - opened
       - edited
       - synchronize
-      - reopened
 
 permissions:
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   main:
-    name: Validate PR
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+            
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:   
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to enhance the validation of pull request titles. The changes include modifying permissions, adding a step to lint PR titles, and handling error messages more effectively.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/validate-pr.yml`](diffhunk://#diff-ef32acb9d5950c00a5a7772cbb1ceaf9af9fa55943bea01aa393a22154e48f9aL9-R45): Changed permissions from `pull-requests: read` to `pull-requests: write`.
* [`.github/workflows/validate-pr.yml`](diffhunk://#diff-ef32acb9d5950c00a5a7772cbb1ceaf9af9fa55943bea01aa393a22154e48f9aL9-R45): Added a step to use `amannn/action-semantic-pull-request@v5` for linting PR titles and capturing error messages.
* [`.github/workflows/validate-pr.yml`](diffhunk://#diff-ef32acb9d5950c00a5a7772cbb1ceaf9af9fa55943bea01aa393a22154e48f9aL9-R45): Integrated `marocchino/sticky-pull-request-comment@v2` to post a comment with the error message if the title linting fails.
* [`.github/workflows/validate-pr.yml`](diffhunk://#diff-ef32acb9d5950c00a5a7772cbb1ceaf9af9fa55943bea01aa393a22154e48f9aL9-R45): Added a conditional step to delete the error comment once the issue has been resolved.